### PR TITLE
Adjust link to quinn crate entry point in docs

### DIFF
--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -6,7 +6,7 @@
 //! builds on top of quinn-proto, which implements protocol logic independent of any particular
 //! runtime.
 //!
-//! The entry point of this crate is the [`Endpoint`](generic/struct.Endpoint.html).
+//! The entry point of this crate is the [`Endpoint`](struct.Endpoint.html).
 //!
 //! # About QUIC
 //!


### PR DESCRIPTION
The link to `Endpoint` in the documentation for the new release (in the sentence "The entry point of this crate is the `Endpoint`." at the top of the page) points into the no longer existent "generic" directory. This fixes that link.